### PR TITLE
Add PLN to list of accepted currencies

### DIFF
--- a/zvt_feig_terminal/src/config.rs
+++ b/zvt_feig_terminal/src/config.rs
@@ -74,6 +74,7 @@ fn iso_4217(code: &str) -> Result<usize> {
         "SEK" => Ok(752),
         "GBP" => Ok(826),
         "EUR" => Ok(978),
+        "PLN" => Ok(985),
         _ => bail!("Unknown currency code {code}"),
     }
 }


### PR DESCRIPTION
This MRs adds support for PLN as a currency accepted in ZVT.