### PR TITLE
Make the get_system_info interface public

### DIFF
--- a/zvt_feig_terminal/src/feig.rs
+++ b/zvt_feig_terminal/src/feig.rs
@@ -112,7 +112,7 @@ impl Feig {
     }
 
     /// Returns the system information of the feig-terminal.
-    async fn get_system_info(
+    pub async fn get_system_info(
         &mut self,
     ) -> Result<feig::packets::CVendFunctionsEnhancedSystemInformationCompletion> {
         let request = feig::packets::CVendFunctions {


### PR DESCRIPTION
This allows for applications using this library to do checks/error handling of their own if they so wish.