### PR TITLE
Add explicit error type to the TID ensure statement

### DIFF
--- a/zvt_feig_terminal/src/feig.rs
+++ b/zvt_feig_terminal/src/feig.rs
@@ -353,6 +353,7 @@ impl Feig {
         }
         self.initialize().await?;
         self.end_of_day().await?;
+        self.successfully_configured = true;
 
         Ok(())
     }

--- a/zvt_feig_terminal/src/feig.rs
+++ b/zvt_feig_terminal/src/feig.rs
@@ -54,6 +54,9 @@ pub enum Error {
 
     #[error("The presented card requires a PIN entry.")]
     NeedsPinEntry,
+
+    #[error("The config TID failed to be set")]
+    TidMismatch,
 }
 
 /// Default card type, which is chip-card, as defined in Table 6.
@@ -179,7 +182,10 @@ impl Feig {
                 sequences::SetTerminalIdResponse::CompletionData(_) => {
                     drop(stream);
                     let system_info = self.get_system_info().await?;
-                    ensure!(system_info.terminal_id == config.terminal_id);
+                    ensure!(
+                        system_info.terminal_id == config.terminal_id,
+                        Error::TidMismatch
+                    );
                     return Ok(true);
                 }
                 sequences::SetTerminalIdResponse::Abort(data) => {


### PR DESCRIPTION
We add a new error variant and add it to the already existing `ensure()` call so that it can be caught in user space and handled